### PR TITLE
Distance calculation improvements/standardization (use Levenshtein vs. Hamming)

### DIFF
--- a/cualid/fix.py
+++ b/cualid/fix.py
@@ -1,15 +1,15 @@
-from difflib import get_close_matches
+from .mint import get_near_matches
 
 
-def fix_ids(correct_input, input_to_check, thresh=.5):
+def fix_ids(correct_input, input_to_check):
     corr_ids = [e.strip().split('\t')[1] for e in correct_input]
 
     broke_ids = [e.strip().split('\t')[0] for e in input_to_check]
 
     seen = set()
     for broke_id in broke_ids:
-        fixed_id = get_close_matches(broke_id, corr_ids, 1, thresh)
-        if not fixed_id:
+        fixed_id = get_near_matches(broke_id, corr_ids)
+        if len(fixed_id) != 1:
             fixed_id = ''
         else:
             fixed_id = fixed_id[0]

--- a/cualid/tests/test_fix.py
+++ b/cualid/tests/test_fix.py
@@ -64,7 +64,7 @@ class TestFixIDs(unittest.TestCase):
 correct1 = io.StringIO("c0b5d3ae-d2d4-4aa5-bd51-76c93e223bb9\t23bb9\n"
                        "0b95a10f-0610-434f-9734-4d2ac02c0cab\tc0cab\n"
                        "ef09be86-dfee-4ce1-84d4-e60b5df87696\t87696\n"
-                       "c13f1644-cab9-4474-b674-1442efc7869b\t7869b\n"
+                       "c13f1644-cab9-4474-b674-1442efc7849b\t7849b\n"
                        "b60e7c07-bbf9-468c-a8f0-98639f2d50cc\td50cc\n")
 
 correct2 = io.StringIO("9563938c-72db-4cf4-aa1c-b8843ce05576\t843ce05576\n"
@@ -77,7 +77,7 @@ correct2 = io.StringIO("9563938c-72db-4cf4-aa1c-b8843ce05576\t843ce05576\n"
 identical = io.StringIO("23bb9\n"
                         "c0cab\n"
                         "87696\n"
-                        "7869b\n"
+                        "7849b\n"
                         "d50cc\n")
 
 bad = io.StringIO("xxxxx\n"

--- a/cualid/tests/test_mint.py
+++ b/cualid/tests/test_mint.py
@@ -35,6 +35,7 @@ class TestAtLeastDistance(unittest.TestCase):
     def test_long(self):
         collection = ['abcdefghijk', 'a-c^efghijk', 'abcdef@h$jk']
 
+        self.assertFalse(at_least_distance('bcdefghijk', collection))
         self.assertTrue(at_least_distance('a_defghi_k', collection))
         self.assertTrue(at_least_distance('abcd___hijk', collection))
 


### PR DESCRIPTION
This PR (for discussion) updates cual-id's distance handling in two ways:

1. Use the Levenshtein distance instead of Hamming, which also handles transposition style errors (note this is slower, but still generates hundreds or thousands of IDs in a reasonable timeframe)

2. Make `fix.py` use the same distance calculation function as `mint.py` (which is strictly more correct as using a different distance function could erroneously "fix" an ID to one of several best matches instead of correctly finding the single value < `edit_distance`)


These are fairly minor (and 2 is probably quite unlikely to pose a problem in practice), but probably useful / a good practice. 